### PR TITLE
Change autoload to use newer spl_autoload_register

### DIFF
--- a/include/init.php
+++ b/include/init.php
@@ -3,20 +3,15 @@
 // This code is licensed pursuant to the Wowza Public License version 1.0, available at www.wowza.com/legal.
 //
 <?php
-function __autoload($className)
-{
-	$arr= explode("\\",$className);
-	$className = array_pop($arr);
-
-	$dirs = array("lib","lib/entities/application","lib/entities","lib/entities/application/helpers");
-
-	foreach($dirs as $dir)
-	{
-		$file = BASE_DIR."/".$dir."/class.".strtolower($className).".php";
-		if(file_exists($file))
-		{
-			require_once($file);
+spl_autoload_register( function( $className ) {
+	$arr = explode( '\\', $className );
+	$className = array_pop( $arr );
+	$dirs = array( 'lib', 'lib/entities/application', 'lib/entities', 'lib/entities/application/helpers' );
+	foreach ( $dirs as $dir ) {
+		$file = BASE_DIR.'/'.$dir.'/class.'.strtolower( $className ).'.php';
+		if ( file_exists( $file ) ) {
+			require_once( $file );
 		}
 	}
-}
+});
 ?>


### PR DESCRIPTION
__autoload may soon be deprecated due to changes in PHP.

http://php.net/manual/en/function.spl-autoload-register.php
http://php.net/manual/en/language.oop5.autoload.php

Autoload is also not available in PHP-CLI. Please consider updating your code to use the more robust spl_autoload_register as included to resolve many issues today and potentially tomorrow.