### PR TITLE
fix Strict Standards error

### DIFF
--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -33,7 +33,8 @@ abstract class Entity
 
     public function getEntityName()
     {
-        $className = array_pop(explode("\\", get_class($this)));
+        $className = explode("\\", get_class($this));
+        $className = array_pop($className);
 
         return lcfirst($className);
     }


### PR DESCRIPTION
Using `array_pop(explode())` produces a strict standards error

http://php.net/manual/en/language.references.pass.php