### PR TITLE
Make _additional & _skip parameters usable outside classes

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -32,25 +32,28 @@ class Application extends Wowza
         $this->restURI = $this->getHost() . "/servers/" . $this->getServerInstance() . "/vhosts/" . $this->getVHostInstance() . "/applications/{$name}";
     }
 
+    private function setParameters()
+    {
+        $this->addSkipParameter('name', true)
+            ->addSkipParameter('clientStreamReadAccess', true)
+            ->addSkipParameter('appType', true)
+            ->addSkipParameter('clientStreamWriteAccess', true)
+            ->addSkipParameter('description', true);
+
+    }
+
     public function get()
     {
-        $this->_skip["name"] = true;
-        $this->_skip["clientStreamReadAccess"] = true;
-        $this->_skip["appType"] = true;
-        $this->_skip["clientStreamWriteAccess"] = true;
-        $this->_skip["description"] = true;
+        $this->setParameters();
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
     }
 
     public function getAll()
     {
-        $this->_skip["name"] = true;
-        $this->_skip["clientStreamReadAccess"] = true;
-        $this->_skip["appType"] = true;
-        $this->_skip["clientStreamWriteAccess"] = true;
-        $this->_skip["description"] = true;
-        $this->restURI = $this->getHost() . "/servers/" . $this->getServerInstance() . "/vhosts/" . $this->getVHostInstance() . "/applications";
+        $this->setParameters();
+
+        $this->restURI = $this->getHost() . '/servers/' . $this->getServerInstance() . '/vhosts/' . $this->getVHostInstance() . '/applications';
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
     }

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -29,8 +29,8 @@ class Publisher extends Wowza
 
     public function getAll()
     {
-        $this->_skip["name"] = true;
-        $this->_skip["password"] = true;
+        $this->addSkipParameter('name', true)
+            ->addSkipParameter('password', true);
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
     }

--- a/src/Recording.php
+++ b/src/Recording.php
@@ -113,26 +113,25 @@ class Recording extends Wowza
 
     private function setNoParams()
     {
-        $this->_skip["recordName"] = true;
-        $this->_skip["instanceName"] = true;
-        $this->_skip["recorderState"] = true;
-        $this->_skip["defaultRecorder"] = true;
-        $this->_skip["segmentationType"] = true;
-        $this->_skip["outputPath"] = true;
-        $this->_skip["baseFile"] = true;
-        $this->_skip["fileFormat"] = true;
-        $this->_skip["fileVersionDelegateName"] = true;
-        $this->_skip["fileTemplate"] = true;
-        $this->_skip["segmentDuration"] = true;
-        $this->_skip["segmentSize"] = true;
-        $this->_skip["segmentSchedule"] = true;
-        $this->_skip["recordData"] = true;
-        $this->_skip["startOnKeyFrame"] = true;
-        $this->_skip["splitOnTcDiscontinuity"] = true;
-        $this->_skip["option"] = true;
-        $this->_skip["moveFirstVideoFrameToZero"] = true;
-        $this->_skip["currentSize"] = true;
-        $this->_skip["currentDuration"] = true;
-        $this->_skip["recordingStartTime"] = true;
+        $this->addSkipParameter('recordName', true)
+            ->addSkipParameter('instanceName', true)
+            ->addSkipParameter('recorderState', true)
+            ->addSkipParameter('defaultRecorder', true)
+            ->addSkipParameter('segmentationType', true)
+            ->addSkipParameter('outputPath', true)
+            ->addSkipParameter('baseFile', true)
+            ->addSkipParameter('fileFormat', true)
+            ->addSkipParameter('fileVersionDelegateName', true)
+            ->addSkipParameter('fileTemplate', true)
+            ->addSkipParameter('segmentDuration', true)
+            ->addSkipParameter('segmentSize', true)
+            ->addSkipParameter('segmentSchedule', true)
+            ->addSkipParameter('startOnKeyFrame', true)
+            ->addSkipParameter('splitOnTcDiscontinuity', true)
+            ->addSkipParameter('option', true)
+            ->addSkipParameter('moveFirstVideoFrameToZero', true)
+            ->addSkipParameter('currentSize', true)
+            ->addSkipParameter('currentDuration', true)
+            ->addSkipParameter('recordingStartTime', true);
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -28,9 +28,10 @@ class Server extends Wowza
     public function createUser($name, $password, $groups = [])
     {
         $this->restURI .= "/users/{$name}";
-        $this->_additional["name"] = $name;
-        $this->_additional["password"] = $password;
-        $this->_additional["groups"] = $groups;
+        $this->addAdditionalParameter('name', $name)
+            ->addAdditionalParameter('password', $password)
+            ->addAdditionalParameter('groups', $groups);
+
         $entities = $this->getEntites([], $this->restURI);
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), []);

--- a/src/SmilFile.php
+++ b/src/SmilFile.php
@@ -30,7 +30,7 @@ class SmilFile extends Wowza
 
     public function get($fileName)
     {
-        $this->_skip["smilStreams"] = true;
+        $this->addSkipParameter('smilStreams', true);
         $this->restURI = $this->restURI . "/" . $fileName;
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
@@ -38,15 +38,15 @@ class SmilFile extends Wowza
 
     public function getAll()
     {
-        $this->_skip["smilStreams"] = true;
+        $this->addSkipParameter('smilStreams', true);
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
     }
 
     public function remove($fileName)
     {
-        $this->_skip["smilStreams"] = true;
-        $this->restURI = $this->restURI . "/" . $fileName;
+        $this->addSkipParameter('smilStreams', true);
+        $this->restURI = $this->restURI . '/' . $fileName;
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_DELETE);
     }

--- a/src/StreamFile.php
+++ b/src/StreamFile.php
@@ -72,13 +72,9 @@ class StreamFile extends Wowza
     private function addURL($advancedSettings)
     {
         $this->_skip["name"] = 1;
-        $this->_additional["version"] = "1430601267443";
-        $this->restURI = $this->restURI . "/adv";
-        if (is_array($advancedSettings)) {
-            $this->_additional["advancedSettings"] = $advancedSettings;
-        } else {
-            $this->_additional["advancedSettings"] = [$advancedSettings];
-        }
+        $this->restURI .= '/adv';
+        $this->addAdditionalParameter('version', '1430601267443')
+            ->addAdditionalParameter('advancedSettings', (array) $advancedSettings);
 
         $entities = $this->getEntites(func_get_args(), null);
 

--- a/src/StreamFile.php
+++ b/src/StreamFile.php
@@ -38,7 +38,7 @@ class StreamFile extends Wowza
 
     public function get()
     {
-        $this->_skip["name"] = true;
+        $this->addSkipParameter('name', true);
         $this->restURI .= "/" . $this->name;
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
@@ -46,7 +46,7 @@ class StreamFile extends Wowza
 
     public function getAll()
     {
-        $this->_skip["name"] = true;
+        $this->addSkipParameter('name', true);
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
     }
@@ -71,7 +71,7 @@ class StreamFile extends Wowza
 
     private function addURL($advancedSettings)
     {
-        $this->_skip["name"] = 1;
+        $this->addSkipParameter('name', 1);
         $this->restURI .= '/adv';
         $this->addAdditionalParameter('version', '1430601267443')
             ->addAdditionalParameter('advancedSettings', (array) $advancedSettings);
@@ -111,7 +111,7 @@ class StreamFile extends Wowza
 
     public function remove()
     {
-        $this->_skip["name"] = 1;
+        $this->addSkipParameter('name', 1);
         $this->restURI = $this->restURI . "/" . $this->name;
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_DELETE);
@@ -119,7 +119,7 @@ class StreamFile extends Wowza
 
     public function connect($subFolder = "")
     {
-        $this->_skip["name"] = 1;
+        $this->addSkipParameter('name', 1);
 // 		$this->_additional["connectAppName"]=$this->_applicationName;
 // 		$this->_additional["appInstance"]=$this->_applicationInstance;
 // 		$this->_additional["mediaCasterType"]=$this->_mediaCasterType;
@@ -139,7 +139,7 @@ class StreamFile extends Wowza
          *
          * "http:\/\/127.0.0.1:8087\/v2\/servers\/_defaultServer_\/vhosts\/_defaultVHost_\/applications\/live\/instances\/_definst_\/incomingstreams\/bolton_mass\/actions\/disconnectStream"
          */
-        $this->_skip["name"] = 1;
+        $this->addSkipParameter('name', 1);
 // 		$this->_additional["connectAppName"]=$this->_applicationName;
 // 		$this->_additional["appInstance"]=$this->_applicationInstance;
 // 		$this->_additional["mediaCasterType"]=$this->_mediaCasterType;
@@ -161,9 +161,10 @@ class StreamFile extends Wowza
          *
          * "http:\/\/127.0.0.1:8087\/v2\/servers\/_defaultServer_\/vhosts\/_defaultVHost_\/applications\/live\/instances\/_definst_\/incomingstreams\/bolton_mass\/actions\/resetStream"
          */
-        $this->_skip["name"]=1;
+        $this->addSkipParameter('name', 1);
         $this->restURI = $this->getHost()."/servers/".$this->getServerInstance()."/vhosts/".$this->getVHostInstance()."/applications/".$this->_applicationName."/instances/";
         $this->restURI .= $this->_applicationInstance."/incomingstreams/".$this->name.".stream/actions/resetStream";
+
         return $this->sendRequest($this->preparePropertiesForRequest(),array(), self::VERB_PUT);
     }
 }

--- a/src/StreamTarget.php
+++ b/src/StreamTarget.php
@@ -59,17 +59,15 @@ class StreamTarget extends Wowza
 
     private function setNoParams()
     {
-        $this->_skip["userName"] = true;
-        $this->_skip["password"] = true;
-        $this->_skip["group"] = true;
-        $this->_skip["sourceStreamName"] = true;
-        $this->_skip["entryName"] = true;
-        $this->_skip["profile"] = true;
-        $this->_skip["host"] = true;
-        $this->_skip["application"] = true;
-        $this->_skip["userName"] = true;
-        $this->_skip["password"] = true;
-        $this->_skip["streamName"] = true;
+        $this->addSkipParameter('userName', true) //todo: correct key name?
+            ->addSkipParameter('password', true)
+            ->addSkipParameter('group', true)
+            ->addSkipParameter('sourceStreamName', true)
+            ->addSkipParameter('entryName', true)
+            ->addSkipParameter('profile', true)
+            ->addSkipParameter('host', true)
+            ->addSkipParameter('application', true)
+            ->addSkipParameter('streamName', true);
     }
 
     public function remove($entryName)

--- a/src/User.php
+++ b/src/User.php
@@ -32,9 +32,9 @@ class User extends Wowza
 
     public function getAll()
     {
-        $this->_skip["userName"] = true;
-        $this->_skip["password"] = true;
-        $this->_skip["group"] = true;
+        $this->addSkipParameter('userName', true) //todo: is this key correct??
+            ->addSkipParameter('password', true)
+            ->addSkipParameter('group', true);
 
         return $this->sendRequest($this->preparePropertiesForRequest(self::class), [], self::VERB_GET);
     }

--- a/src/Wowza.php
+++ b/src/Wowza.php
@@ -10,14 +10,14 @@ use Com\Wowza\Entities\Application\Helpers\Settings;
 
 class Wowza
 {
-    const VERB_POST = "POST";
-    const VERB_GET = "GET";
-    const VERB_DELETE = "DELETE";
-    const VERB_PUT = "PUT";
+    const VERB_POST = 'POST';
+    const VERB_GET = 'GET';
+    const VERB_DELETE = 'DELETE';
+    const VERB_PUT = 'PUT';
 
-    protected $restURI = "";
+    protected $restURI = '';
     protected $_skip = [];
-    protected $_additional = [];
+    private $_additional = [];
 
     private $settings;
 
@@ -79,10 +79,11 @@ class Wowza
     protected function sendRequest($props, $entities, $verbType = self::VERB_POST, $queryParams = null)
     {
         if (isset($props->restURI) && !empty($props->restURI)) {
-            if (count($entities) > 0) {
-                for ($i = 0; $i < count($entities); $i++) {
+            $entityCount = count($entities);
+            if ($entityCount > 0) {
+                for ($i = 0; $i < $entityCount; $i++) {
                     $entity = $entities[$i];
-                    if (is_object($entity) && method_exists($entity, "getEntityName")) {
+                    if (is_object($entity) && method_exists($entity, 'getEntityName')) {
                         $name = $entity->getEntityName();
                         $props->$name = $entity;
                     }
@@ -91,8 +92,8 @@ class Wowza
             $json = json_encode($props);
 
             $restURL = $props->restURI;
-            if (!is_null($queryParams)) {
-                $restURL .= "?" . $queryParams;
+            if (null !== $queryParams) {
+                $restURL .= '?' . $queryParams;
             }
             $this->debug("JSON REQUEST to {$restURL} with verb {$verbType}: " . $json);
 
@@ -121,6 +122,19 @@ class Wowza
         }
 
         return false;
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     *
+     * @return $this
+     */
+    public function addAdditionalParameter($key, $value)
+    {
+        $this->_additional[$key] = $value;
+
+        return $this;
     }
 
     protected function preparePropertiesForRequest($class)

--- a/src/Wowza.php
+++ b/src/Wowza.php
@@ -16,7 +16,7 @@ class Wowza
     const VERB_PUT = 'PUT';
 
     protected $restURI = '';
-    protected $_skip = [];
+    private $_skip = [];
     private $_additional = [];
 
     private $settings;
@@ -136,6 +136,18 @@ class Wowza
 
         return $this;
     }
+    /**
+     * @param $key
+     * @param $value
+     *
+     * @return $this
+     */
+    public function addSkipParameter($key, $value)
+    {
+        $this->_skip[$key] = $value;
+
+        return $this;
+    }
 
     protected function preparePropertiesForRequest($class)
     {
@@ -147,7 +159,7 @@ class Wowza
                 if (preg_match("/^(\_)/", $key)) {
                     continue;
                 }
-                if (isset($this->_skip[$key])) {
+                if (array_key_exists($key, $this->_skip)) {
                     continue;
                 }
                 $props->$key = $this->$key;


### PR DESCRIPTION
Hi there,

It was needed for me using _additional parameter outside `StreamTarget` class. Because i need to send extra parameters when request to create a new Stream Target. 

Since it was `protected` variable, i was not able to add new key-value pair in that array. 
So i changed this two variable to `private` and added a new method to update this variables. Of course updated all usages too. This doesn't break anything for peoples who uses this repo. Still, since there is no unit tests, this pull request should check carefully and tested locally. 

Now you can generate query like this:

```php
$streamTarget = new \Com\Wowza\StreamTarget($this->settings, 'live');
$streamTarget->addAdditionalParameter('facebook.destName', 'My Timeline')
    ->addAdditionalParameter('facebook.accessToken', 'ENC-4e0d218731282783-bla-bla-bla-many-chars')

$streamTarget->create(...);
```

By this usage, my required parameters will be sent to endpoint 
