### PR TITLE
Removes unused variables from constructor signature

### DIFF
--- a/src/StreamFile.php
+++ b/src/StreamFile.php
@@ -20,9 +20,7 @@ class StreamFile extends Wowza
     public function __construct(
         Settings $settings,
         $appName = null,
-        $streamFileName = null,
-        $serverInstance = "_defaultServer_",
-        $vhostInstance = "_defaultVHost_"
+        $streamFileName = null
     ) {
         parent::__construct($settings);
         $this->restURI = $this->getHost() . "/servers/" . $this->getServerInstance() . "/vhosts/" . $this->getVHostInstance() . "/streamfiles";


### PR DESCRIPTION
$serverInstance and $vhostInstance are never used. They were replaced by calls to parent class methods getServerInstance() and getVHostInstance() respectively.